### PR TITLE
Program Configuration Interface

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,7 @@
 API_URL=
 # Funded EOA on Gnosis Chain
 REDEEMER_KEY=
+
+# Optional (fixed defaults)
+SUBSCRIPTION_MODULE=0xcEbE4B6d50Ce877A9689ce4516Fe96911e099A78
+CIRCLES_RPC=https://rpc.aboutcircles.com/

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,68 @@
+import type { Address, Hex } from "viem";
+import { createWalletClient, getAddress, http, publicActions } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { gnosis } from "viem/chains";
+import { ConnectedWallet, Secrets } from "./types";
+
+export interface Config {
+  apiUrl: URL;
+  redeemer: ConnectedWallet;
+  circlesRpc: string;
+  subscriptionModule: Address;
+}
+
+// Default values
+export const DEFAULT_CIRCLES_RPC = "https://rpc.aboutcircles.com/";
+export const DEFAULT_SUBSCRIPTION_MODULE =
+  "0xcEbE4B6d50Ce877A9689ce4516Fe96911e099A78";
+
+// Create a secrets object that reads from environment variables
+const secrets: Secrets = {
+  get: async (key: string): Promise<string> => {
+    const value = process.env[key];
+    if (!value) {
+      throw new Error(`Environment variable ${key} is not set`);
+    }
+    return value;
+  },
+};
+
+async function getSecrets(
+  secrets: Secrets,
+): Promise<{ redeemerKey: `0x${string}`; apiUrl: URL }> {
+  const [apiUrl, pk] = await Promise.all([
+    secrets.get("API_URL"),
+    secrets.get("REDEEMER_KEY"),
+  ]);
+  return {
+    redeemerKey: pk.startsWith("0x") ? (pk as Hex) : `0x${pk}`,
+    apiUrl: new URL(apiUrl),
+  };
+}
+
+/**
+ * Loads configuration:
+ * - API_URL, REDEEMER_KEY via provided Secrets
+ * - CIRCLES_RPC, SUBSCRIPTION_MODULE via env or defaults from constants
+ */
+export async function loadConfig(): Promise<Config> {
+  const { apiUrl, redeemerKey } = await getSecrets(secrets);
+  const redeemer = createWalletClient({
+    account: privateKeyToAccount(redeemerKey),
+    chain: gnosis,
+    transport: http(),
+  }).extend(publicActions);
+
+  const circlesRpc = process.env.CIRCLES_RPC ?? DEFAULT_CIRCLES_RPC;
+
+  const subscriptionModule = getAddress(
+    process.env.SUBSCRIPTION_MODULE ?? DEFAULT_SUBSCRIPTION_MODULE,
+  );
+
+  return {
+    apiUrl,
+    redeemer,
+    circlesRpc,
+    subscriptionModule,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,15 @@
-import { createWalletClient, http, publicActions } from "viem";
-import { gnosis } from "viem/chains";
-import { privateKeyToAccount } from "viem/accounts";
-
 import { redeemPayment } from "./redeem";
-import { fetchRedeemableSubscriptions, getSecrets } from "./utils";
-import { Secrets } from "./types";
+import { fetchRedeemableSubscriptions } from "./utils";
+import { loadConfig, Config } from "./config";
 
-export async function runRedeemer(secrets: Secrets): Promise<void> {
-  const { redeemerKey, apiUrl } = await getSecrets(secrets);
-  const redeemable = await fetchRedeemableSubscriptions(apiUrl);
+export async function runRedeemer(config: Config): Promise<void> {
+  const redeemable = await fetchRedeemableSubscriptions(config.apiUrl);
   console.log(
     `Found ${redeemable.length} redeemable subscription(s): ${JSON.stringify(redeemable, null, 2)}`,
   );
-  const redeemer = createWalletClient({
-    account: privateKeyToAccount(redeemerKey),
-    chain: gnosis,
-    transport: http(),
-  }).extend(publicActions);
   for (const subscription of redeemable) {
     try {
-      await redeemPayment(redeemer, subscription);
+      await redeemPayment(config, subscription);
     } catch (err) {
       throw new Error(`Failed to redeem ${subscription.id}: ${err}`);
     }
@@ -28,20 +18,10 @@ export async function runRedeemer(secrets: Secrets): Promise<void> {
 
 // Docker entry point - constructs secrets from environment variables
 export async function main(): Promise<void> {
-  // Create a secrets object that reads from environment variables
-  const secrets: Secrets = {
-    get: async (key: string): Promise<string> => {
-      const value = process.env[key];
-      if (!value) {
-        throw new Error(`Environment variable ${key} is not set`);
-      }
-      return value;
-    },
-  };
-
   try {
     console.log("Starting redeemer process...");
-    await runRedeemer(secrets);
+    const config = await loadConfig();
+    await runRedeemer(config);
     console.log("Redeemer process completed");
   } catch (error) {
     console.error("Redeemer process failed:", error);

--- a/src/redeem.ts
+++ b/src/redeem.ts
@@ -1,35 +1,28 @@
-import { getAddress, Hex, parseAbi } from "viem";
-import { Category, RedeemableSubscription, ConnectedWallet } from "./types";
+import { Hex, parseAbi } from "viem";
+import { Category, RedeemableSubscription } from "./types";
 import { encodeCallData } from "./encode";
 import { getFlowMatrix } from "./utils";
-
-const CIRCLES_RPC = "https://rpc.aboutcircles.com/";
-const SUBSCRIPTION_MODULE = getAddress(
-  "0xcEbE4B6d50Ce877A9689ce4516Fe96911e099A78",
-);
-
-const transactionData = {
-  address: SUBSCRIPTION_MODULE,
-  abi: parseAbi(["function redeem(bytes32 id, bytes calldata data)"]),
-  functionName: "redeem",
-} as const;
+import { Config } from "./config";
 
 export async function redeemPayment(
-  redeemer: ConnectedWallet,
+  { subscriptionModule, circlesRpc, redeemer }: Config,
   subscription: RedeemableSubscription,
 ): Promise<void> {
   const { id, category } = subscription;
   console.log("Redeeming with", redeemer.account.address);
+
   try {
     let calldata = "0x" as Hex;
     if (category === Category.Trusted) {
-      const flowMatrix = await getFlowMatrix(CIRCLES_RPC, subscription);
+      const flowMatrix = await getFlowMatrix(circlesRpc, subscription);
       console.log("FlowMatrix", flowMatrix);
       calldata = encodeCallData(flowMatrix);
     }
 
     const txHash = await redeemer.writeContract({
-      ...transactionData,
+      address: subscriptionModule,
+      abi: parseAbi(["function redeem(bytes32 id, bytes calldata data)"]),
+      functionName: "redeem",
       args: [id, calldata],
     });
     console.log(`Redeemed ${id} at:`, txHash);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,19 +1,5 @@
-import { Hex } from "viem";
-import { RedeemableSubscription, Secrets } from "./types";
+import { RedeemableSubscription } from "./types";
 import { createFlowMatrix, findPath, FlowMatrix } from "./circles";
-
-export async function getSecrets(
-  secrets: Secrets,
-): Promise<{ redeemerKey: `0x${string}`; apiUrl: URL }> {
-  const [apiUrl, pk] = await Promise.all([
-    secrets.get("API_URL"),
-    secrets.get("REDEEMER_KEY"),
-  ]);
-  return {
-    redeemerKey: pk.startsWith("0x") ? (pk as Hex) : `0x${pk}`,
-    apiUrl: new URL(apiUrl),
-  };
-}
 
 export async function fetchRedeemableSubscriptions(
   apiUrl: URL,


### PR DESCRIPTION
Cleaning up the Secrets vs Constants into a single program `Config` whose secrets and constants are read from env, while the constants are non-required env vars with defaults. Namely

apiUrl, redeemerKey, subscriptionModule and circlesRpc

This would make contract redeployment a bit easier to manage (without code changes).